### PR TITLE
Update streamlit to 1.11.1 - security advisory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ asgiref==3.5.2
 asttokens==2.0.5
 attrs==21.4.0
 backcall==0.2.0
+backports.zoneinfo==0.2.1
 beautifulsoup4==4.11.1
 bleach==5.0.0
 blinker==1.4
@@ -31,6 +32,7 @@ h11==0.13.0
 httptools==0.4.0
 idna==3.3
 importlib-metadata==4.11.4
+importlib-resources==5.8.0
 ipykernel==6.13.0
 ipython==8.3.0
 ipython-genutils==0.2.0
@@ -93,7 +95,7 @@ sniffio==1.2.0
 soupsieve==2.3.2.post1
 stack-data==0.2.0
 starlette==0.19.1
-streamlit==1.10.0
+streamlit==1.11.1
 terminado==0.15.0
 tinycss2==1.1.1
 toml==0.10.2


### PR DESCRIPTION
Updated streamlit to 1.11.1 following a security advisory from the streamlit team,

[advisory](https://docs.google.com/document/u/1/d/e/2PACX-1vRzF9K6gwv9KnQz---1pt0SdHMVt-CHuKMmdTH1uct7xPcK7vToP4FvYdI84aO6rGfCmrBSaViri0Nd/pub?utm_medium=email&_hsmi=221161828&_hsenc=p2ANqtz--giLO2BSH5W-fShSrEtpaZiRPPdPIcAgkJxk2bGI0s3VNLDtwwpJKVFt1dB16YFrPI8EVm1vDsukPqy2uLL_dZDrMNOlwUlAIwqIDAeZM-cODSqxY&utm_content=221161828&utm_source=hs_email)