### PR TITLE
Set a document title

### DIFF
--- a/app_streamlit.py
+++ b/app_streamlit.py
@@ -10,6 +10,11 @@ from convertor import MOHSampleManifestConversion
 from convertor.core.conversion_log import ConversionLog
 from convertor.freezeman import freezeman_template
 
+
+# Set the dom document title. 
+# Note: the page config needs to be the first streamlit command used by the app.
+st.set_page_config(page_title="Freezeman MGC Template Convertor")
+
 @dataclass
 class ConversionState:
     uploaded_template: Optional[BinaryIO] = None


### PR DESCRIPTION
Set a document title for the app to "Freezeman MGC Template Convertor" so that bookmarks have a sensible name. Right now, convertor's name is "app_streamlit.py" and that gets used as a bookmark name.