### PR TITLE
Improve log output and suppress warnings

### DIFF
--- a/app_streamlit.py
+++ b/app_streamlit.py
@@ -48,6 +48,9 @@ def handle_upload():
         freezeman_template = PurePath(FMS_SUBMISSION_TEMPLATE_PATH)
         output_stream = BytesIO()
 
+        # Write the file name to console to keep track of user activity
+        print(f"Converting file: {state.uploaded_template.name}")
+
         convertor = MOHSampleManifestConversion(state.uploaded_template, freezeman_template, output_stream)
         convertor.do_conversion()
 
@@ -60,8 +63,11 @@ def handle_upload():
         state.freezeman_template_name = converted_file_name
         state.conversion_log = convertor.log
         state.conversion_error = None
+
+        print("done")
         
     except Exception as e:
+        print(f"An error occured during conversion: ", e)
         state.conversion_error = e
 
 

--- a/convertor/moh/sample_manifest.py
+++ b/convertor/moh/sample_manifest.py
@@ -64,7 +64,8 @@ class MOHSampleManifest:
                 num_mismatches += 1
                 if num_mismatches > MAX_MISMATCHED_HEADER_CELLS:
                     return None
-        print("Mismatched headers: ", mismatched_headers)
+        if len(mismatched_headers) > 0:
+            print("Mismatched headers: ", mismatched_headers)
 
         return matched_headers
 

--- a/convertor/sample_manifest_conversion.py
+++ b/convertor/sample_manifest_conversion.py
@@ -1,11 +1,17 @@
 # from pathlib import PurePath
 import pandas
+import warnings
 
 from .core import ConversionLog, ManifestError
 from .freezeman import FHSSampleSubmissionTemplate
 from .moh import MOHSampleManifest, MOHSampleManifestExtractor
 
-
+# Disable openpyxl warnings that show up every time the freezeman template is loaded
+warnings.filterwarnings("ignore", module="openpyxl", category=UserWarning)
+# warnings.filterwarnings("ignore", category=UserWarning, message="Conditional Formatting extension is not supported and will be removed")
+# warnings.filterwarnings("ignore", category=UserWarning, message="Data Validation extension is not supported and will be removed")
+# warnings.filterwarnings("ignore", category=UserWarning, message="Unknown extension is not supported and will be removed")
+# 
 class MOHSampleManifestConversion:
     # Implements the conversion of one MOH sample manifest using files
     def __init__(
@@ -55,7 +61,7 @@ class MOHSampleManifestConversion:
                 "There was a problem with the manifest contents"
             ) from err
 
-        print("Data rows in manifest: ", manifest.get_data_row_range())
+        # print("Data rows in manifest: ", manifest.get_data_row_range())
 
         return manifest
 


### PR DESCRIPTION
Improve the logged output. Log when convertor is busy converting a file and suppress useless warnings from openpyxl.