### PR TITLE
Fix column headers moh error

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -42,7 +42,7 @@ def convert(manifest_file_path, output_path):
         conversion.do_conversion()
     except Exception as e:
         # Capture any exception so that we can still write the log file
-        sys.stderr.write('Conversion failed')
+        sys.stderr.write('Conversion failed\n')
         sys.stderr.write(str(e))
     finally:
         # Write log no matter what happens, since we capture exception

--- a/convertor/moh/sample_manifest.py
+++ b/convertor/moh/sample_manifest.py
@@ -44,10 +44,9 @@ class MOHSampleManifest:
 
         num_mismatches = 0
         for col in rowTuple:
-
             # If a row cell contains anything other than a string then it is not a header row
             if not isinstance(col, str):
-                return None
+                continue
 
             # replace newline or tab characters with spaces, and strip * chars
             cleaned = col.replace("\n", " ").strip(" \t\r\*")
@@ -58,16 +57,19 @@ class MOHSampleManifest:
 
             if cleaned in self.cleaned_headers:
                 matched_headers.append(cleaned)
+                if len(matched_headers) == len(self.cleaned_headers):
+                    return matched_headers
             else:
                 mismatched_headers.append(cleaned)
                 matched_headers.append(f"UNKNOWN{num_mismatches}")
                 num_mismatches += 1
                 if num_mismatches > MAX_MISMATCHED_HEADER_CELLS:
-                    return None
+                    break
+
         if len(mismatched_headers) > 0:
             print("Mismatched headers: ", mismatched_headers)
 
-        return matched_headers
+        return None
 
     def _find_header_row_index(self):
         MAX_ROWS_TO_CHECK = 10

--- a/convertor/moh/sample_manifest_extractor.py
+++ b/convertor/moh/sample_manifest_extractor.py
@@ -203,7 +203,7 @@ class MOHSampleManifestExtractor:
         container_type = self._extract_value(row, MOHHeaders.CONTAINER_TYPE)
         container_name = self._extract_value(row, MOHHeaders.CONTAINER_NAME)
         container_barcode = self._extract_value(row, MOHHeaders.CONTAINER_BARCODE)
-        well = self._normalize_well(self._extract_value(row, MOHHeaders.WELL))
+        well = self._normalize_well(self._extract_value(row, MOHHeaders.WELL, force_string=True))
 
 
         # Replace spaces in container name with underscore '_'


### PR DESCRIPTION
Add fixes for column header detection in the MOH submission template. Convertor would fail if the user added extra data in the columns to the right of the submission form.